### PR TITLE
Add image4k to playlist features

### DIFF
--- a/node.json
+++ b/node.json
@@ -14,7 +14,7 @@
             "name": "file",
             "type": "resource",
             "valid": ["image", "video"],
-            "features": ["hevc"],
+            "features": ["hevc", "image4k"],
             "default": "empty.png"
         }, {
             "title": "Play time",


### PR DESCRIPTION
I was unable to use 4K images with this package. After adding `image4k` to the features, it works like a charm.
I'm not sure, if this change has implications for older devices (older than rpi 4) ...